### PR TITLE
Add support for ignored fields

### DIFF
--- a/load/field.go
+++ b/load/field.go
@@ -57,7 +57,7 @@ func newField(parent *Naked, i int) (*Field, error) {
 		return nil, nil
 	}
 	log.Printf("loading field %s", stField.Name())
-	m := parseTags(parent.st.Tag(i))
+	m := tags.Parse(parent.st.Tag(i))[tagSQLType]
 	if m != nil && len(m) == 1 {
 		if _, ok := m["-"]; ok {
 			return nil, nil
@@ -100,14 +100,6 @@ func newField(parent *Naked, i int) (*Field, error) {
 // distinct between a field with name 'Field' in StructA, the name will be 'StructBField'
 func (f *Field) Name() string {
 	return strings.Replace(f.AccessName, ".", "", -1)
-}
-
-func parseTags(tag string) map[string]string {
-	if tag == "" {
-		return nil
-	}
-	tagsMap := tags.Parse(tag)
-	return tagsMap[tagSQLType]
 }
 
 // parseTags parses tags from a struct tags into a SQL struct.

--- a/load/field.go
+++ b/load/field.go
@@ -97,14 +97,17 @@ func (f *Field) Name() string {
 	return strings.Replace(f.AccessName, ".", "", -1)
 }
 
-// parseTags parses tags from a struct tags into a SQL struct.
-func (f *Field) parseTags(tag string) error {
+func parseTags(tag string) map[string]string {
 	if tag == "" {
 		return nil
 	}
-
 	tagsMap := tags.Parse(tag)
-	for key, value := range tagsMap[tagSQLType] {
+	return tagsMap[tagSQLType]
+}
+
+// parseTags parses tags from a struct tags into a SQL struct.
+func (f *Field) parseTags(tag string) error {
+	for key, value := range parseTags(tag) {
 		switch key {
 		case "type":
 			var err error

--- a/load/load_test.go
+++ b/load/load_test.go
@@ -55,6 +55,16 @@ func TestLoad(t *testing.T) {
 			},
 			wantImportPath: "github.com/posener/orm/tests",
 		},
+		{
+			typeName:      "../tests.Ignore",
+			wantName:      "Ignore",
+			wantFullName:  "tests.Ignore",
+			wantLocalName: "Ignore",
+			wantFields: []*Field{
+				{AccessName: "ID", Type: Type{Naked: &Naked{Name: "int64"}}},
+			},
+			wantImportPath: "github.com/posener/orm/tests",
+		},
 	}
 
 	for _, tt := range tests {

--- a/load/type.go
+++ b/load/type.go
@@ -89,12 +89,6 @@ func (t *Naked) LoadFields(levels int) error {
 		return nil
 	}
 	for i := 0; i < t.st.NumFields(); i++ {
-		m := parseTags(t.st.Tag(i))
-		if m != nil && len(m) == 1 {
-			if _, ok := m["-"]; ok {
-				continue
-			}
-		}
 		field, err := newField(t, i)
 		if err != nil {
 			return err

--- a/load/type.go
+++ b/load/type.go
@@ -89,6 +89,12 @@ func (t *Naked) LoadFields(levels int) error {
 		return nil
 	}
 	for i := 0; i < t.st.NumFields(); i++ {
+		m := parseTags(t.st.Tag(i))
+		if m != nil && len(m) == 1 {
+			if _, ok := m["-"]; ok {
+				continue
+			}
+		}
 		field, err := newField(t, i)
 		if err != nil {
 			return err

--- a/tests/types.go
+++ b/tests/types.go
@@ -76,3 +76,9 @@ type All struct {
 	// test a case where field is a reserved name
 	Select int
 }
+
+// Ignore contains ignored fields.
+type Ignore struct {
+	ID   int64
+	Data map[string]interface{} `sql:"-"`
+}


### PR DESCRIPTION
Right now all fiedlds are used for generation as long as they are exported.

There are many occations where the struct can contains fields which are not mapped to database  columns for instance

```go
type Foo struct {
	ID   int64
	Data map[string]interface{} `sql:"-"`
}
```

The Data field is not supposed to be mapped to  any database columns.

So, adding a `sql:"-"` tag will skip/ignore  the field.